### PR TITLE
fix: Correct get operation for KMIP 2.0

### DIFF
--- a/base_objects.go
+++ b/base_objects.go
@@ -126,12 +126,10 @@ type AttestationCredentialValue struct {
 // The Key Block SHALL contain a Key Wrapping Data structure if the key in the Key Value field is
 // wrapped (i.e., encrypted, or MACed/signed, or both).
 //
-// TODO: Unmarshaler impl which unmarshals correct KeyValue type.
 type KeyBlock struct {
-	KeyFormatType      kmip14.KeyFormatType
-	KeyCompressionType kmip14.KeyCompressionType `ttlv:",omitempty"`
-	// KeyValue should be either []byte or KeyValue
-	KeyValue               interface{}                   `ttlv:",omitempty"` // should be either a []byte or KeyValue
+	KeyFormatType          kmip14.KeyFormatType
+	KeyCompressionType     kmip14.KeyCompressionType     `ttlv:",omitempty"`
+	KeyValue               KeyValue                      `ttlv:",omitempty"`
 	CryptographicAlgorithm kmip14.CryptographicAlgorithm `ttlv:",omitempty"`
 	CryptographicLength    int                           `ttlv:",omitempty"`
 	KeyWrappingData        *KeyWrappingData
@@ -153,7 +151,7 @@ type KeyBlock struct {
 type KeyValue struct {
 	// KeyMaterial should be []byte, one of the Transparent*Key structs, or a custom struct if KeyFormatType is
 	// an extension.
-	KeyMaterial interface{}
+	KeyMaterial []byte
 	Attribute   []Attribute
 }
 

--- a/kmip20/op_get.go
+++ b/kmip20/op_get.go
@@ -13,11 +13,22 @@ type GetRequestPayload struct {
 	UniqueIdentifier UniqueIdentifierValue
 }
 
+// Example:
+// ObjectType (Enumeration/4): SymmetricKey
+// UniqueIdentifier (TextString/4): 5976
+// SymmetricKey (Structure/104):
+//   KeyBlock (Structure/96):
+//     KeyFormatType (Enumeration/4): Raw
+//     KeyValue (Structure/40):
+//       KeyMaterial (ByteString/32): 0x1645497fb8ca4f568aba750c7b764ce2700696a5918b2acc9857fae2b1b9f764
+//     CryptographicAlgorithm (Enumeration/4): AES
+//     CryptographicLength (Integer/4): 256 MessageExtension:<nil>}
+
 // GetResponsePayload
 type GetResponsePayload struct {
 	ObjectType       kmip14.ObjectType
 	UniqueIdentifier string
-	Key              kmip.SymmetricKey
+	SymmetricKey     kmip.SymmetricKey
 }
 
 type GetHandler struct {


### PR DESCRIPTION
- Adjust KMIP 2.0 get operation types to correct the reception of the Key Material.
- For KeyKeyValue, KeyMaterial is now a byte slice, []byte
- For KeyBlock, KeyValue was modified to be a KeyValue type
- For kmip20/op_get GetResponsePayload, Key is now SymmetricKey
Signed-off-by: Joe Skazinski <joseph.skazinski@seagate.com>