### PR TITLE
chore: Move common under kmipapi for clarity when used by other repos

### DIFF
--- a/cmd/kms/CHANGELOG.md
+++ b/cmd/kms/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [1.1.2] (2022-09-13)
+
+### Chore
+
+- Move common package files under the src/kmipapi package
+
 # [1.1.1] (2022-09-12)
 
 ### Fix

--- a/cmd/kms/README.md
+++ b/cmd/kms/README.md
@@ -321,11 +321,6 @@ return errors and let the higher level user interface print messages. Logging is
   - Creates a `kms) ` prompt and scans user input.
   - For each command entered after the `kms) ` prompt, the **handlers.Execute()** is called passing in context, settings, and the input text line.
 
-`src/common`:
-- `config.go` to **Store** and **Restore** the configuration settings file - writes and reads JSON data to and from a file.
-- `parsers.go` to handle parsing **key=value** pairs from the command line string entered by a user.
-- `types.go` to declare common types such as **ConfigurationSettings**.
-
 `src/handlers`:
 - The `handlers.go` file initializes a map of function pointers. All functions must take the same list and types of parameters.
 - Update `g_handlers` to add a new row with a command string and function pointer.
@@ -337,6 +332,9 @@ return errors and let the higher level user interface print messages. Logging is
 
 `src/kmipapi`:
 - A Go interface for executing various versions of KMIP commands.
+- `config.go` to **Store** and **Restore** the configuration settings file - writes and reads JSON data to and from a file.
+- `parsers.go` to handle parsing **key=value** pairs from the command line string entered by a user.
+- `types.go` to declare common types such as **ConfigurationSettings**.
 - `kmipservice.go` is used to extract a pointer the correct KMIP protocol version instantiation.
 - `clientops.go` contains the Request and Response message definitions for all supported KMIP operations.
 - `clientapi.go` contains all of the KMS and KMIP functions needed for KMIP operations. These are called by the handlers.

--- a/cmd/kms/main.go
+++ b/cmd/kms/main.go
@@ -7,13 +7,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Seagate/kmip-go/src/common"
 	"github.com/Seagate/kmip-go/src/handlers"
 	"github.com/Seagate/kmip-go/src/kmipapi"
 	"k8s.io/klog/v2"
 )
 
-const version string = "1.1.1"
+const version string = "1.1.2"
 
 // init: called once during program execution
 func init() {
@@ -47,7 +46,7 @@ func main() {
 
 	fmt.Printf("[] kms (version=%s)\n\n", version)
 
-	settings := common.ConfigurationSettings{
+	settings := kmipapi.ConfigurationSettings{
 		ProtocolVersionMajor: 1,
 		ProtocolVersionMinor: 4,
 		ServiceType:          kmipapi.KMIP14Service,
@@ -58,7 +57,7 @@ func main() {
 	// Restore any previously stored configuration settings
 	filename := "kms.json"
 	if _, err := os.Stat(filename); err == nil {
-		common.Restore(ctx, &settings, filename)
+		kmipapi.Restore(ctx, &settings, filename)
 	}
 
 	scanner := bufio.NewScanner(os.Stdin)

--- a/src/handlers/env.go
+++ b/src/handlers/env.go
@@ -10,14 +10,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Seagate/kmip-go/src/common"
 	"github.com/Seagate/kmip-go/src/kmipapi"
 	"github.com/fatih/color"
 	"k8s.io/klog/v2"
 )
 
 // Env: usage 'env' to display all configuration settings
-func Env(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Env(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Env:", "line", line)
 
@@ -51,16 +50,16 @@ func Env(ctx context.Context, settings *common.ConfigurationSettings, line strin
 }
 
 // Version: usage 'version [major=<value>] [minor=<value>]' to set KMIP protocol version
-func Version(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Version(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Version:", "line", line)
 
-	major := common.GetValue(line, "major")
+	major := kmipapi.GetValue(line, "major")
 	if major == "" {
 		major = "1"
 	}
 
-	minor := common.GetValue(line, "minor")
+	minor := kmipapi.GetValue(line, "minor")
 	if minor == "" {
 		minor = "4"
 	}
@@ -75,11 +74,11 @@ func Version(ctx context.Context, settings *common.ConfigurationSettings, line s
 	}
 
 	fmt.Printf("kmip protocol version %s.%s\n", major, minor)
-	common.Store(ctx, settings)
+	kmipapi.Store(ctx, settings)
 }
 
 // Certs: usage 'certs [ca=<value>] [key=<value>] [cert=<value>]' to set certificate PEM files
-func Certs(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Certs(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Certs:", "line", line)
 
@@ -87,7 +86,7 @@ func Certs(ctx context.Context, settings *common.ConfigurationSettings, line str
 	keys := [3]string{"ca", "key", "cert"}
 
 	for _, key := range keys {
-		value := common.GetValue(line, key)
+		value := kmipapi.GetValue(line, key)
 		if value != "" {
 			switch key {
 			case "ca":
@@ -107,16 +106,16 @@ func Certs(ctx context.Context, settings *common.ConfigurationSettings, line str
 	}
 
 	if updated {
-		common.Store(ctx, settings)
+		kmipapi.Store(ctx, settings)
 	}
 }
 
 // Run: usage 'run file=<value>' to execute all commands in a file
-func Run(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Run(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Run:", "line", line)
 
-	filename := common.GetValue(line, "file")
+	filename := kmipapi.GetValue(line, "file")
 
 	if _, err := os.Stat(filename); errors.Is(err, os.ErrNotExist) {
 		fmt.Printf("File (%s) does not exist\n", filename)
@@ -142,48 +141,48 @@ func Run(ctx context.Context, settings *common.ConfigurationSettings, line strin
 }
 
 // Set: usage 'set [level=<value>] [ip=<value>] [port=<value>] [name=<value>]' to change a configuration setting
-func Set(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Set(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Set:", "line", line)
 
 	// set the log level
-	level := common.GetValue(line, "level")
+	level := kmipapi.GetValue(line, "level")
 	if level != "" {
 		flag.Lookup("v").Value.Set(level)
 	}
 
 	// set the KMS Server name
-	name := common.GetValue(line, "name")
+	name := kmipapi.GetValue(line, "name")
 	if name != "" {
 		settings.KmsServerName = name
 		fmt.Printf("KmsServerName set to: %s\n", name)
 	}
 
 	// set the KMS Server IP Address
-	ip := common.GetValue(line, "ip")
+	ip := kmipapi.GetValue(line, "ip")
 	if ip != "" {
 		settings.KmsServerIp = ip
 		fmt.Printf("KmsServerIp set to: %s\n", ip)
 	}
 
 	// set the KMS Server Port
-	port := common.GetValue(line, "port")
+	port := kmipapi.GetValue(line, "port")
 	if port != "" {
 		settings.KmsServerPort = port
 		fmt.Printf("KmsServerPort set to: %s\n", port)
 	}
 
-	common.Store(ctx, settings)
+	kmipapi.Store(ctx, settings)
 }
 
 // Load: usage 'load file=<value>' to load configuration settings from a file
-func Load(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Load(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Load:", "line", line)
 
-	filename := common.GetValue(line, "file")
+	filename := kmipapi.GetValue(line, "file")
 	if filename != "" {
-		err := common.Restore(ctx, settings, filename)
+		err := kmipapi.Restore(ctx, settings, filename)
 		if err == nil {
 			settings.SettingsFile = filename
 			fmt.Printf("configuration settings read from (%s)\n", settings.SettingsFile)

--- a/src/handlers/handlers.go
+++ b/src/handlers/handlers.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Seagate/kmip-go/src/common"
+	"github.com/Seagate/kmip-go/src/kmipapi"
 )
 
-type CommandHandler func(context.Context, *common.ConfigurationSettings, string)
+type CommandHandler func(context.Context, *kmipapi.ConfigurationSettings, string)
 
 var g_handlers map[string]CommandHandler
 
@@ -35,8 +35,8 @@ func Initialize() {
 }
 
 // Execute: execute a handler with the text line
-func Execute(ctx context.Context, settings *common.ConfigurationSettings, line string) {
-	f, ok := g_handlers[common.GetCommand(line)]
+func Execute(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
+	f, ok := g_handlers[kmipapi.GetCommand(line)]
 	if ok {
 		f(ctx, settings, line)
 	} else {

--- a/src/handlers/help.go
+++ b/src/handlers/help.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Seagate/kmip-go/src/common"
+	"github.com/Seagate/kmip-go/src/kmipapi"
 	"github.com/fatih/color"
 	"k8s.io/klog/v2"
 )
 
-func Help(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Help(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Help:", "line", line)
 

--- a/src/handlers/key.go
+++ b/src/handlers/key.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/Seagate/kmip-go/kmip14"
-	"github.com/Seagate/kmip-go/src/common"
 	"github.com/Seagate/kmip-go/src/kmipapi"
 	"k8s.io/klog/v2"
 )
@@ -17,11 +16,11 @@ import (
 //
 
 // CreateKey: usage 'create id=<value>' to create a new kmip cryptographic key
-func CreateKey(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func CreateKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("CreateKey", "line", line)
 
-	id := common.GetValue(line, "id")
+	id := kmipapi.GetValue(line, "id")
 	if id == "" {
 		fmt.Printf("create id=value is required, example: create id=ZAD0YA320000C7300BYS\n")
 		return
@@ -37,11 +36,11 @@ func CreateKey(ctx context.Context, settings *common.ConfigurationSettings, line
 }
 
 // ActivateKey: usage 'activate uid=<value>' to activate unique identifier
-func ActivateKey(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func ActivateKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("ActivateKey", "line", line)
 
-	uid := common.GetValue(line, "uid")
+	uid := kmipapi.GetValue(line, "uid")
 	if uid == "" {
 		fmt.Printf("activate uid=value is required, example: activate uid=6201\n")
 		return
@@ -57,11 +56,11 @@ func ActivateKey(ctx context.Context, settings *common.ConfigurationSettings, li
 }
 
 // GetKey: usage 'get uid=<value>' to retrieve kmip cryptographic key material
-func GetKey(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func GetKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("GetKey", "line", line)
 
-	uid := common.GetValue(line, "uid")
+	uid := kmipapi.GetValue(line, "uid")
 
 	if uid == "" {
 		fmt.Printf("get uid=value is required, example: get uid=6201\n")
@@ -78,11 +77,11 @@ func GetKey(ctx context.Context, settings *common.ConfigurationSettings, line st
 }
 
 // LocateKey: usage 'locate id=<value>' to return the uid of the id, where id is required
-func LocateKey(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func LocateKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("LocateKey", "line", line)
 
-	id := common.GetValue(line, "id")
+	id := kmipapi.GetValue(line, "id")
 
 	if id == "" {
 		fmt.Printf("locate id=value is required, example: locate id=ZAD0YA320000C7300BYS\n")
@@ -99,11 +98,11 @@ func LocateKey(ctx context.Context, settings *common.ConfigurationSettings, line
 }
 
 // RevokeKey: usage 'revoke uid=<value>' to revoke a key based on uid
-func RevokeKey(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func RevokeKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("RevokeKey", "line", line)
 
-	uid := common.GetValue(line, "uid")
+	uid := kmipapi.GetValue(line, "uid")
 	if uid == "" {
 		fmt.Printf("revoke uid=value is required, example: revoke id=6307\n")
 		return
@@ -119,11 +118,11 @@ func RevokeKey(ctx context.Context, settings *common.ConfigurationSettings, line
 }
 
 // DestroyKey: usage 'destroy uid=<value>' to destroy a key based on uid
-func DestroyKey(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func DestroyKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("DestroyKey", "line", line)
 
-	uid := common.GetValue(line, "uid")
+	uid := kmipapi.GetValue(line, "uid")
 	if uid == "" {
 		fmt.Printf("destroy uid=value is required, example: destroy id=6307\n")
 		return

--- a/src/handlers/server.go
+++ b/src/handlers/server.go
@@ -6,23 +6,22 @@ import (
 	"strconv"
 
 	"github.com/Seagate/kmip-go"
-	"github.com/Seagate/kmip-go/src/common"
 	"github.com/Seagate/kmip-go/src/kmipapi"
 	"k8s.io/klog/v2"
 )
 
 // Open: Read PEM files and establish a TLS connection with the KMS server
-func Open(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Open(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Open:", "line", line)
 
 	// Read command line arguments
-	ip := common.GetValue(line, "ip")
+	ip := kmipapi.GetValue(line, "ip")
 	if ip != "" {
 		settings.KmsServerIp = ip
 		fmt.Printf("KmsServerIp set to: %s\n", ip)
 	}
-	port := common.GetValue(line, "port")
+	port := kmipapi.GetValue(line, "port")
 	if port != "" {
 		settings.KmsServerPort = port
 		fmt.Printf("KmsServerPort set to: %s\n", port)
@@ -38,7 +37,7 @@ func Open(ctx context.Context, settings *common.ConfigurationSettings, line stri
 }
 
 // Close: Close the TLS connection
-func Close(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Close(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Close:", "line", line)
 
@@ -51,13 +50,13 @@ func Close(ctx context.Context, settings *common.ConfigurationSettings, line str
 }
 
 // Discover: Discover versions supported by a KMS Server
-func Discover(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Discover(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Discover:", "line", line)
 
 	// Read command line arguments
-	major := common.GetValue(line, "major")
-	minor := common.GetValue(line, "minor")
+	major := kmipapi.GetValue(line, "major")
+	minor := kmipapi.GetValue(line, "minor")
 
 	versions := []kmip.ProtocolVersion{}
 
@@ -76,12 +75,12 @@ func Discover(ctx context.Context, settings *common.ConfigurationSettings, line 
 }
 
 // Query: Query the KMS Server with a specified operation
-func Query(ctx context.Context, settings *common.ConfigurationSettings, line string) {
+func Query(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Query:", "line", line)
 
 	// Read command line arguments
-	operation := common.GetValue(line, "op")
+	operation := kmipapi.GetValue(line, "op")
 
 	results, err := kmipapi.QueryServer(ctx, settings, operation)
 	if err == nil {

--- a/src/kmipapi/clientapi.go
+++ b/src/kmipapi/clientapi.go
@@ -13,12 +13,11 @@ import (
 
 	"github.com/Seagate/kmip-go"
 	"github.com/Seagate/kmip-go/kmip14"
-	"github.com/Seagate/kmip-go/src/common"
 	"k8s.io/klog/v2"
 )
 
 // OpenSession: Read PEM files and establish a TLS connection with the KMS server
-func OpenSession(ctx context.Context, settings *common.ConfigurationSettings) error {
+func OpenSession(ctx context.Context, settings *ConfigurationSettings) error {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Open TLS session", "KmsServerIp", settings.KmsServerIp, "KmsServerPort", settings.KmsServerPort)
 
@@ -81,7 +80,7 @@ func OpenSession(ctx context.Context, settings *common.ConfigurationSettings) er
 }
 
 // CloseSession: Close the TLS connection with the KMS Server
-func CloseSession(ctx context.Context, settings *common.ConfigurationSettings) error {
+func CloseSession(ctx context.Context, settings *ConfigurationSettings) error {
 	logger := klog.FromContext(ctx)
 
 	if settings.Connection != nil {
@@ -97,7 +96,7 @@ func CloseSession(ctx context.Context, settings *common.ConfigurationSettings) e
 }
 
 // Discover: Perform a discover operation to retrieve KMIP protocol versions supported.
-func DiscoverServer(ctx context.Context, settings *common.ConfigurationSettings, clientVersions []kmip.ProtocolVersion) ([]kmip.ProtocolVersion, error) {
+func DiscoverServer(ctx context.Context, settings *ConfigurationSettings, clientVersions []kmip.ProtocolVersion) ([]kmip.ProtocolVersion, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("   ++ discover server", "clientVersions", clientVersions)
 
@@ -125,7 +124,7 @@ func DiscoverServer(ctx context.Context, settings *common.ConfigurationSettings,
 }
 
 // QueryServer: Perform a query operation.
-func QueryServer(ctx context.Context, settings *common.ConfigurationSettings, operation string) (string, error) {
+func QueryServer(ctx context.Context, settings *ConfigurationSettings, operation string) (string, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("   ++ querying server", "operation", operation)
 
@@ -159,7 +158,7 @@ func QueryServer(ctx context.Context, settings *common.ConfigurationSettings, op
 }
 
 // CreateKey: Create a unique identifier for a id and return that uid
-func CreateKey(ctx context.Context, settings *common.ConfigurationSettings, id string) (string, error) {
+func CreateKey(ctx context.Context, settings *ConfigurationSettings, id string) (string, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("++ create key", "id", id)
 
@@ -190,7 +189,7 @@ func CreateKey(ctx context.Context, settings *common.ConfigurationSettings, id s
 }
 
 // ActivateKey: Activate a key created using a unique identifier
-func ActivateKey(ctx context.Context, settings *common.ConfigurationSettings, uid string) (string, error) {
+func ActivateKey(ctx context.Context, settings *ConfigurationSettings, uid string) (string, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("++ activate key", "uid", uid)
 
@@ -216,7 +215,7 @@ func ActivateKey(ctx context.Context, settings *common.ConfigurationSettings, ui
 }
 
 // GetKey: Retrieve a key for a specified UID
-func GetKey(ctx context.Context, settings *common.ConfigurationSettings, uid string) (key string, err error) {
+func GetKey(ctx context.Context, settings *ConfigurationSettings, uid string) (key string, err error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("++ get key", "uid", uid)
 
@@ -243,7 +242,7 @@ func GetKey(ctx context.Context, settings *common.ConfigurationSettings, uid str
 }
 
 // LocateUid: retrieve a UID for a ID
-func LocateUid(ctx context.Context, settings *common.ConfigurationSettings, id string) (string, error) {
+func LocateUid(ctx context.Context, settings *ConfigurationSettings, id string) (string, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("++ locate uid", "id", id)
 
@@ -269,7 +268,7 @@ func LocateUid(ctx context.Context, settings *common.ConfigurationSettings, id s
 }
 
 // RevokeKey: revoke a key based on UID
-func RevokeKey(ctx context.Context, settings *common.ConfigurationSettings, uid string, reason uint32) (string, error) {
+func RevokeKey(ctx context.Context, settings *ConfigurationSettings, uid string, reason uint32) (string, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("++ revoke key", "uid", uid)
 
@@ -296,7 +295,7 @@ func RevokeKey(ctx context.Context, settings *common.ConfigurationSettings, uid 
 }
 
 // DestroyKey: destroy a key based on UID
-func DestroyKey(ctx context.Context, settings *common.ConfigurationSettings, uid string) (string, error) {
+func DestroyKey(ctx context.Context, settings *ConfigurationSettings, uid string) (string, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("++ destroy key", "uid", uid)
 

--- a/src/kmipapi/config.go
+++ b/src/kmipapi/config.go
@@ -1,4 +1,4 @@
-package common
+package kmipapi
 
 import (
 	"context"

--- a/src/kmipapi/kmip14.go
+++ b/src/kmipapi/kmip14.go
@@ -9,13 +9,12 @@ import (
 
 	"github.com/Seagate/kmip-go"
 	"github.com/Seagate/kmip-go/kmip14"
-	"github.com/Seagate/kmip-go/src/common"
 	"github.com/Seagate/kmip-go/ttlv"
 	"k8s.io/klog/v2"
 )
 
 // Discover: Send a KMIP OperationDiscoverVersion message
-func (kmips *kmip14service) Discover(ctx context.Context, settings *common.ConfigurationSettings, req *DiscoverRequest) (*DiscoverResponse, error) {
+func (kmips *kmip14service) Discover(ctx context.Context, settings *ConfigurationSettings, req *DiscoverRequest) (*DiscoverResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== kmip discover ======")
 
@@ -43,7 +42,7 @@ func (kmips *kmip14service) Discover(ctx context.Context, settings *common.Confi
 }
 
 // Query: Retrieve info about KMIP server
-func (kmips *kmip14service) Query(ctx context.Context, settings *common.ConfigurationSettings, req *QueryRequest) (*QueryResponse, error) {
+func (kmips *kmip14service) Query(ctx context.Context, settings *ConfigurationSettings, req *QueryRequest) (*QueryResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== query server ======", "id", req.Id)
 
@@ -85,7 +84,7 @@ func (kmips *kmip14service) Query(ctx context.Context, settings *common.Configur
 }
 
 // CreateKey: Send a KMIP OperationCreate message
-func (kmips *kmip14service) CreateKey(ctx context.Context, settings *common.ConfigurationSettings, req *CreateKeyRequest) (*CreateKeyResponse, error) {
+func (kmips *kmip14service) CreateKey(ctx context.Context, settings *ConfigurationSettings, req *CreateKeyRequest) (*CreateKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 
 	type createReqAttrs struct {
@@ -136,7 +135,7 @@ func (kmips *kmip14service) CreateKey(ctx context.Context, settings *common.Conf
 }
 
 // GetKey: Send a KMIP OperationGet message
-func (kmips *kmip14service) GetKey(ctx context.Context, settings *common.ConfigurationSettings, req *GetKeyRequest) (*GetKeyResponse, error) {
+func (kmips *kmip14service) GetKey(ctx context.Context, settings *ConfigurationSettings, req *GetKeyRequest) (*GetKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== get key ======", "uid", req.UniqueIdentifier)
 
@@ -186,7 +185,7 @@ func (kmips *kmip14service) GetKey(ctx context.Context, settings *common.Configu
 }
 
 // DestroyKey:
-func (kmips *kmip14service) DestroyKey(ctx context.Context, settings *common.ConfigurationSettings, req *DestroyKeyRequest) (*DestroyKeyResponse, error) {
+func (kmips *kmip14service) DestroyKey(ctx context.Context, settings *ConfigurationSettings, req *DestroyKeyRequest) (*DestroyKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== destroy key ======", "uid", req.UniqueIdentifier)
 
@@ -213,7 +212,7 @@ func (kmips *kmip14service) DestroyKey(ctx context.Context, settings *common.Con
 }
 
 // ActivateKey:
-func (kmips *kmip14service) ActivateKey(ctx context.Context, settings *common.ConfigurationSettings, req *ActivateKeyRequest) (*ActivateKeyResponse, error) {
+func (kmips *kmip14service) ActivateKey(ctx context.Context, settings *ConfigurationSettings, req *ActivateKeyRequest) (*ActivateKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== activate key ======", "uid", req.UniqueIdentifier)
 
@@ -240,7 +239,7 @@ func (kmips *kmip14service) ActivateKey(ctx context.Context, settings *common.Co
 }
 
 // RevokeKey:
-func (kmips *kmip14service) RevokeKey(ctx context.Context, settings *common.ConfigurationSettings, req *RevokeKeyRequest) (*RevokeKeyResponse, error) {
+func (kmips *kmip14service) RevokeKey(ctx context.Context, settings *ConfigurationSettings, req *RevokeKeyRequest) (*RevokeKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== revoke key ======", "uid", req.UniqueIdentifier)
 
@@ -272,12 +271,12 @@ func (kmips *kmip14service) RevokeKey(ctx context.Context, settings *common.Conf
 }
 
 // Register: Not Implemented
-func (kmips *kmip14service) Register(ctx context.Context, settings *common.ConfigurationSettings, req *RegisterRequest) (*RegisterResponse, error) {
+func (kmips *kmip14service) Register(ctx context.Context, settings *ConfigurationSettings, req *RegisterRequest) (*RegisterResponse, error) {
 	return &RegisterResponse{}, fmt.Errorf("command is not implemented")
 }
 
 // Locate:
-func (kmips *kmip14service) Locate(ctx context.Context, settings *common.ConfigurationSettings, req *LocateRequest) (*LocateResponse, error) {
+func (kmips *kmip14service) Locate(ctx context.Context, settings *ConfigurationSettings, req *LocateRequest) (*LocateResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== locate ======", "name", req.Name)
 
@@ -309,12 +308,12 @@ func (kmips *kmip14service) Locate(ctx context.Context, settings *common.Configu
 }
 
 // SetAttribute: Not Supported
-func (kmips *kmip14service) SetAttribute(ctx context.Context, settings *common.ConfigurationSettings, req *SetAttributeRequest) (*SetAttributeResponse, error) {
+func (kmips *kmip14service) SetAttribute(ctx context.Context, settings *ConfigurationSettings, req *SetAttributeRequest) (*SetAttributeResponse, error) {
 	return &SetAttributeResponse{}, fmt.Errorf("SetAttribute command is not supported")
 }
 
 // ReKey:
-func (kmips *kmip14service) ReKey(ctx context.Context, settings *common.ConfigurationSettings, req *ReKeyRequest) (*ReKeyResponse, error) {
+func (kmips *kmip14service) ReKey(ctx context.Context, settings *ConfigurationSettings, req *ReKeyRequest) (*ReKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== rekey ======", "uid", req.UniqueIdentifier)
 

--- a/src/kmipapi/kmip20.go
+++ b/src/kmipapi/kmip20.go
@@ -10,13 +10,12 @@ import (
 	"github.com/Seagate/kmip-go"
 	"github.com/Seagate/kmip-go/kmip14"
 	"github.com/Seagate/kmip-go/kmip20"
-	"github.com/Seagate/kmip-go/src/common"
 	"github.com/Seagate/kmip-go/ttlv"
 	"k8s.io/klog/v2"
 )
 
 // Discover: Send a KMIP OperationDiscoverVersion message
-func (kmips *kmip20service) Discover(ctx context.Context, settings *common.ConfigurationSettings, req *DiscoverRequest) (*DiscoverResponse, error) {
+func (kmips *kmip20service) Discover(ctx context.Context, settings *ConfigurationSettings, req *DiscoverRequest) (*DiscoverResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== kmips discover ======")
 
@@ -44,7 +43,7 @@ func (kmips *kmip20service) Discover(ctx context.Context, settings *common.Confi
 }
 
 // Query: Retrieve info about KMIP server
-func (kmips *kmip20service) Query(ctx context.Context, settings *common.ConfigurationSettings, req *QueryRequest) (*QueryResponse, error) {
+func (kmips *kmip20service) Query(ctx context.Context, settings *ConfigurationSettings, req *QueryRequest) (*QueryResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== query server ======", "id", req.Id)
 
@@ -86,7 +85,7 @@ func (kmips *kmip20service) Query(ctx context.Context, settings *common.Configur
 }
 
 // CreateKey: Send a KMIP OperationCreate message
-func (kmips *kmip20service) CreateKey(ctx context.Context, settings *common.ConfigurationSettings, req *CreateKeyRequest) (*CreateKeyResponse, error) {
+func (kmips *kmip20service) CreateKey(ctx context.Context, settings *ConfigurationSettings, req *CreateKeyRequest) (*CreateKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 
 	type createReqAttrs struct {
@@ -136,7 +135,7 @@ func (kmips *kmip20service) CreateKey(ctx context.Context, settings *common.Conf
 }
 
 // GetKey: Send a KMIP OperationGet message to retrieve key material based on a uid
-func (kmips *kmip20service) GetKey(ctx context.Context, settings *common.ConfigurationSettings, req *GetKeyRequest) (*GetKeyResponse, error) {
+func (kmips *kmip20service) GetKey(ctx context.Context, settings *ConfigurationSettings, req *GetKeyRequest) (*GetKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== get key ======", "uid", req.UniqueIdentifier)
 
@@ -200,7 +199,7 @@ func (kmips *kmip20service) GetKey(ctx context.Context, settings *common.Configu
 }
 
 // DestroyKey:
-func (kmips *kmip20service) DestroyKey(ctx context.Context, settings *common.ConfigurationSettings, req *DestroyKeyRequest) (*DestroyKeyResponse, error) {
+func (kmips *kmip20service) DestroyKey(ctx context.Context, settings *ConfigurationSettings, req *DestroyKeyRequest) (*DestroyKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== destroy key ======", "uid", req.UniqueIdentifier)
 
@@ -232,7 +231,7 @@ func (kmips *kmip20service) DestroyKey(ctx context.Context, settings *common.Con
 }
 
 // ActivateKey:
-func (kmips *kmip20service) ActivateKey(ctx context.Context, settings *common.ConfigurationSettings, req *ActivateKeyRequest) (*ActivateKeyResponse, error) {
+func (kmips *kmip20service) ActivateKey(ctx context.Context, settings *ConfigurationSettings, req *ActivateKeyRequest) (*ActivateKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== activate key ======", "uid", req.UniqueIdentifier)
 
@@ -264,7 +263,7 @@ func (kmips *kmip20service) ActivateKey(ctx context.Context, settings *common.Co
 }
 
 // RevokeKey:
-func (kmips *kmip20service) RevokeKey(ctx context.Context, settings *common.ConfigurationSettings, req *RevokeKeyRequest) (*RevokeKeyResponse, error) {
+func (kmips *kmip20service) RevokeKey(ctx context.Context, settings *ConfigurationSettings, req *RevokeKeyRequest) (*RevokeKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== revoke key ======", "uid", req.UniqueIdentifier)
 
@@ -299,12 +298,12 @@ func (kmips *kmip20service) RevokeKey(ctx context.Context, settings *common.Conf
 }
 
 // Register:
-func (kmips *kmip20service) Register(ctx context.Context, settings *common.ConfigurationSettings, req *RegisterRequest) (*RegisterResponse, error) {
+func (kmips *kmip20service) Register(ctx context.Context, settings *ConfigurationSettings, req *RegisterRequest) (*RegisterResponse, error) {
 	return &RegisterResponse{}, fmt.Errorf("ERROR command is not implemented")
 }
 
 // Locate:
-func (kmips *kmip20service) Locate(ctx context.Context, settings *common.ConfigurationSettings, req *LocateRequest) (*LocateResponse, error) {
+func (kmips *kmip20service) Locate(ctx context.Context, settings *ConfigurationSettings, req *LocateRequest) (*LocateResponse, error) {
 	type createReqAttrs struct {
 		Name kmip.Name
 	}
@@ -341,7 +340,7 @@ func (kmips *kmip20service) Locate(ctx context.Context, settings *common.Configu
 }
 
 // SetAttribute:
-func (kmips *kmip20service) SetAttribute(ctx context.Context, settings *common.ConfigurationSettings, req *SetAttributeRequest) (*SetAttributeResponse, error) {
+func (kmips *kmip20service) SetAttribute(ctx context.Context, settings *ConfigurationSettings, req *SetAttributeRequest) (*SetAttributeResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== set attribute ======", "uid", req.UniqueIdentifier, "value", req.AttributeValue)
 
@@ -374,7 +373,7 @@ func (kmips *kmip20service) SetAttribute(ctx context.Context, settings *common.C
 }
 
 // ReKey:
-func (kmips *kmip20service) ReKey(ctx context.Context, settings *common.ConfigurationSettings, req *ReKeyRequest) (*ReKeyResponse, error) {
+func (kmips *kmip20service) ReKey(ctx context.Context, settings *ConfigurationSettings, req *ReKeyRequest) (*ReKeyResponse, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("====== rekey ======", "uid", req.UniqueIdentifier)
 

--- a/src/kmipapi/kmipservice.go
+++ b/src/kmipapi/kmipservice.go
@@ -5,22 +5,20 @@ package kmipapi
 import (
 	"context"
 	"errors"
-
-	"github.com/Seagate/kmip-go/src/common"
 )
 
 type KMIPOperations interface {
-	CreateKey(context.Context, *common.ConfigurationSettings, *CreateKeyRequest) (*CreateKeyResponse, error)
-	GetKey(context.Context, *common.ConfigurationSettings, *GetKeyRequest) (*GetKeyResponse, error)
-	DestroyKey(context.Context, *common.ConfigurationSettings, *DestroyKeyRequest) (*DestroyKeyResponse, error)
-	ActivateKey(context.Context, *common.ConfigurationSettings, *ActivateKeyRequest) (*ActivateKeyResponse, error)
-	RevokeKey(context.Context, *common.ConfigurationSettings, *RevokeKeyRequest) (*RevokeKeyResponse, error)
-	Register(context.Context, *common.ConfigurationSettings, *RegisterRequest) (*RegisterResponse, error)
-	Locate(context.Context, *common.ConfigurationSettings, *LocateRequest) (*LocateResponse, error)
-	Query(context.Context, *common.ConfigurationSettings, *QueryRequest) (*QueryResponse, error)
-	SetAttribute(context.Context, *common.ConfigurationSettings, *SetAttributeRequest) (*SetAttributeResponse, error)
-	Discover(context.Context, *common.ConfigurationSettings, *DiscoverRequest) (*DiscoverResponse, error)
-	ReKey(context.Context, *common.ConfigurationSettings, *ReKeyRequest) (*ReKeyResponse, error)
+	CreateKey(context.Context, *ConfigurationSettings, *CreateKeyRequest) (*CreateKeyResponse, error)
+	GetKey(context.Context, *ConfigurationSettings, *GetKeyRequest) (*GetKeyResponse, error)
+	DestroyKey(context.Context, *ConfigurationSettings, *DestroyKeyRequest) (*DestroyKeyResponse, error)
+	ActivateKey(context.Context, *ConfigurationSettings, *ActivateKeyRequest) (*ActivateKeyResponse, error)
+	RevokeKey(context.Context, *ConfigurationSettings, *RevokeKeyRequest) (*RevokeKeyResponse, error)
+	Register(context.Context, *ConfigurationSettings, *RegisterRequest) (*RegisterResponse, error)
+	Locate(context.Context, *ConfigurationSettings, *LocateRequest) (*LocateResponse, error)
+	Query(context.Context, *ConfigurationSettings, *QueryRequest) (*QueryResponse, error)
+	SetAttribute(context.Context, *ConfigurationSettings, *SetAttributeRequest) (*SetAttributeResponse, error)
+	Discover(context.Context, *ConfigurationSettings, *DiscoverRequest) (*DiscoverResponse, error)
+	ReKey(context.Context, *ConfigurationSettings, *ReKeyRequest) (*ReKeyResponse, error)
 }
 
 type commonservice struct {

--- a/src/kmipapi/parsers.go
+++ b/src/kmipapi/parsers.go
@@ -1,4 +1,4 @@
-package common
+package kmipapi
 
 import (
 	"strings"

--- a/src/kmipapi/send.go
+++ b/src/kmipapi/send.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Seagate/kmip-go"
 	"github.com/Seagate/kmip-go/kmip14"
-	"github.com/Seagate/kmip-go/src/common"
 	"github.com/Seagate/kmip-go/ttlv"
 	"github.com/google/uuid"
 	"k8s.io/klog/v2"
@@ -19,7 +18,7 @@ const (
 )
 
 // SendRequestMessage: Send a KMIP request message
-func SendRequestMessage(ctx context.Context, settings *common.ConfigurationSettings, operation uint32, payload interface{}) (*ttlv.Decoder, *kmip.ResponseBatchItem, error) {
+func SendRequestMessage(ctx context.Context, settings *ConfigurationSettings, operation uint32, payload interface{}) (*ttlv.Decoder, *kmip.ResponseBatchItem, error) {
 	logger := klog.FromContext(ctx)
 	biID := uuid.New()
 

--- a/src/kmipapi/types.go
+++ b/src/kmipapi/types.go
@@ -1,4 +1,4 @@
-package common
+package kmipapi
 
 import "crypto/tls"
 


### PR DESCRIPTION
Move the src/common package and files to the src/kmipapi package. This change will be it clearer to 3rd party repos that use the kmip-go repo, knowing that the function calls and types come from the kmipapi package.

Signed-off-by: Joe Skazinski <joseph.skazinski@seagate.com>

-----
[View rendered cmd/kms/CHANGELOG.md](https://github.com/Seagate/kmip-go/blob/chore/mvcommon/cmd/kms/CHANGELOG.md)
[View rendered cmd/kms/README.md](https://github.com/Seagate/kmip-go/blob/chore/mvcommon/cmd/kms/README.md)