### PR TITLE
chore: Add Rekey and SetAttribute to kmipapi

### DIFF
--- a/src/handlers/handlers.go
+++ b/src/handlers/handlers.go
@@ -31,6 +31,7 @@ func Initialize() {
 		"locate":   LocateKey,
 		"revoke":   RevokeKey,
 		"destroy":  DestroyKey,
+		"register": Register,
 	}
 }
 

--- a/src/handlers/help.go
+++ b/src/handlers/help.go
@@ -48,4 +48,6 @@ func Help(ctx context.Context, settings *kmipapi.ConfigurationSettings, line str
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("locate"), col2, options("id=<value>"), comment("// locate a uid based on a id"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("revoke"), col2, options("uid=<value>"), comment("// revoke a key based on a uid"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("destroy"), col2, options("uid=<value>"), comment("// destroy a key based on a uid"))
+
+	fmt.Printf("  %*s  %-*s  %s\n", col1, command("register"), col2, options("type=<value> value=<value>"), comment("// Register a new value"))
 }

--- a/src/handlers/server.go
+++ b/src/handlers/server.go
@@ -89,3 +89,27 @@ func Query(ctx context.Context, settings *kmipapi.ConfigurationSettings, line st
 		fmt.Printf("Query failed, error: %v\n", err)
 	}
 }
+
+// Register:
+func Register(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Register:", "line", line)
+
+	// Read command line arguments
+	typestr := kmipapi.GetValue(line, "type")
+	if typestr != "" {
+		fmt.Printf("type set to: %s\n", typestr)
+	}
+	value := kmipapi.GetValue(line, "value")
+	if value != "" {
+		fmt.Printf("value set to: %s\n", value)
+	}
+
+	// // Execute the Register command
+	// err := kmipapi.Register(ctx, typestr, value)
+	// if err == nil {
+	// 	fmt.Printf("Register passed\n")
+	// } else {
+	// 	fmt.Printf("Register failed, error: %v\n", err)
+	// }
+}


### PR DESCRIPTION
Add Rekey and SetAttribute to the kmipapi so that clients can use those commands.

Release Notes
- Added Rekey and SetAttribute to kmipapi
- Added example register command shell

Signed-off-by: Joe Skazinski <joseph.skazinski@seagate.com>