### PR TITLE
feat: kms 1.2.0 with banner, clear, elapsed time, lastuid

### DIFF
--- a/cmd/kms/CHANGELOG.md
+++ b/cmd/kms/CHANGELOG.md
@@ -1,3 +1,26 @@
+# [1.2.0] (2022-10-10)
+
+### Features
+
+- Added new command `banner title=value` to print a single word banner.
+  - Example:
+    - `banner title=PyKMIP`
+  - Output:
+    - ============================== PyKMIP ==============================
+- Added new command `set elapsed=true|false` which displays command elapsed time when true
+- Added new command `clear id=value` which will locate, revoke, and destroy a key based on an id
+- Added new variable concept, with one new variable `${lastuid}` which is set after a Create or Locate call. 
+- Example script using last uid variable:
+  - `load file=kms-pykmip.json`
+  - `open`
+  - `create id=DISKSM0123456789`
+  - `activate uid=${lastuid}`
+  - `get uid=${lastuid}`
+  - `locate id=DISKSM0123456789`
+  - `revoke uid=${lastuid}`
+  - `destroy uid=${lastuid}`
+  - `close`
+
 # [1.1.2] (2022-09-13)
 
 ### Chore

--- a/cmd/kms/main.go
+++ b/cmd/kms/main.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const version string = "1.1.2"
+const version string = "1.2.0"
 
 // init: called once during program execution
 func init() {
@@ -69,8 +69,10 @@ func main() {
 				fmt.Println("")
 				os.Exit(0)
 			}
-			handlers.Execute(ctx, &settings, line)
-			fmt.Println("")
+			if line != "" {
+				handlers.Execute(ctx, &settings, line)
+				fmt.Println("")
+			}
 		}
 	}
 }

--- a/op_locate.go
+++ b/op_locate.go
@@ -13,14 +13,13 @@ type LocateRequestPayload struct {
 	// OffsetItems       uint32                   // Required: No
 	// StorageStatusMask kmip14.StorageStatusMask // Required: No
 	// ObjectGroupMember kmip14.ObjectGroupMember // Required: No
-	Attribute []Attribute // Required: No
+	Attributes []Attribute // Required: No
 }
 
 // Table 191
 
 type LocateResponsePayload struct {
-	LocatedItems     uint32   // Required: No
-	UniqueIdentifier []string // Required: No
+	UniqueIdentifier string // Required: No
 }
 
 type LocateHandler struct {

--- a/src/handlers/env.go
+++ b/src/handlers/env.go
@@ -26,7 +26,9 @@ func Env(ctx context.Context, settings *kmipapi.ConfigurationSettings, line stri
 	col1 := 30
 
 	fmt.Println("")
+	fmt.Printf("  %*s  %-v\n", col1, key("SaveSettingsToFile"), value(settings.SaveSettingsToFile))
 	fmt.Printf("  %*s  %-v\n", col1, key("SettingsFile"), value(settings.SettingsFile))
+	fmt.Printf("  %*s  %-v\n", col1, key("ShowElapsed"), value(settings.ShowElapsed))
 
 	fmt.Println("")
 	if settings.Connection == nil {
@@ -172,6 +174,19 @@ func Set(ctx context.Context, settings *kmipapi.ConfigurationSettings, line stri
 		fmt.Printf("KmsServerPort set to: %s\n", port)
 	}
 
+	// set show elapsed to true|false
+	elapsed := kmipapi.GetValue(line, "elapsed")
+	if elapsed != "" {
+		if strings.EqualFold(elapsed, "true") {
+			settings.ShowElapsed = true
+			fmt.Printf("ShowElapsed set to: %v\n", settings.ShowElapsed)
+		}
+		if strings.EqualFold(elapsed, "false") {
+			settings.ShowElapsed = false
+			fmt.Printf("ShowElapsed set to: %v\n", settings.ShowElapsed)
+		}
+	}
+
 	kmipapi.Store(ctx, settings)
 }
 
@@ -188,4 +203,13 @@ func Load(ctx context.Context, settings *kmipapi.ConfigurationSettings, line str
 			fmt.Printf("configuration settings read from (%s)\n", settings.SettingsFile)
 		}
 	}
+}
+
+// Banner: usage 'banner title=<value>' to print a separator banner with a title
+func Banner(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("Banner:", "line", line)
+
+	title := kmipapi.GetValue(line, "title")
+	fmt.Printf("\n%s %s %s\n\n", strings.Repeat("=", 40), title, strings.Repeat("=", 40))
 }

--- a/src/handlers/handlers.go
+++ b/src/handlers/handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Seagate/kmip-go/src/kmipapi"
 )
@@ -21,6 +22,7 @@ func Initialize() {
 		"certs":    Certs,
 		"set":      Set,
 		"load":     Load,
+		"banner":   Banner,
 		"open":     Open,
 		"close":    Close,
 		"discover": Discover,
@@ -32,6 +34,7 @@ func Initialize() {
 		"revoke":   RevokeKey,
 		"destroy":  DestroyKey,
 		"register": Register,
+		"clear":    ClearKey,
 	}
 }
 
@@ -39,7 +42,13 @@ func Initialize() {
 func Execute(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
 	f, ok := g_handlers[kmipapi.GetCommand(line)]
 	if ok {
+		start := time.Now()
 		f(ctx, settings, line)
+		if settings.ShowElapsed {
+			duration := time.Since(start)
+			fmt.Printf("[elapsed=%s] %s\n", duration, kmipapi.GetCommand(line))
+		}
+
 	} else {
 		fmt.Printf("No handler for: %s\n", line)
 	}

--- a/src/handlers/help.go
+++ b/src/handlers/help.go
@@ -29,6 +29,7 @@ func Help(ctx context.Context, settings *kmipapi.ConfigurationSettings, line str
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("set"), col2, options("[level=<value>]"), comment("// change the debug log level 0,1,2,3,4,5,etc"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("set"), col2, options("[ip=<value>] [port=<value>]"), comment("// set the ip and port for the kms server"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("set"), col2, options("[name=<value>]"), comment("// set a name for the kms server"))
+	fmt.Printf("  %*s  %-*s  %s\n", col1, command("set"), col2, options("[elapsed=<true|false>]"), comment("// set show elapsed to true or false"))
 
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("version"), col2, options("[major=<value>] [minor=<value>]"), comment("// change the KMIP protocol version"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("certs"), col2, options("[ca=<value>] [key=<value>] [cert=<value>]"), comment("// change the KMS certificate files"))
@@ -37,7 +38,7 @@ func Help(ctx context.Context, settings *kmipapi.ConfigurationSettings, line str
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("open"), col2, options("[ip=<value>] [port=<value>]"), comment("// open a TLS session, ip and port are optional"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("close"), col2, options(""), comment("// close the TLS session"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("discover"), col2, options("[major=<value> minor=<value>]"), comment("// discover versions supported by a KMS Server"))
-	fmt.Printf("  %*s  %-*s  %s\n", col1, command("query"), col2, options("[op=<value>] [port=<value>]"), comment("// query a KMS Server, operations supported: 1, 3"))
+	fmt.Printf("  %*s  %-*s  %s\n", col1, command("query"), col2, options("[op=<value>]"), comment("// query a KMS Server, operations supported: 1, 3"))
 
 	fmt.Println("")
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("create"), col2, options("id=<value>"), comment("// create a key based on a id, corresponding uid is displayed"))
@@ -48,6 +49,8 @@ func Help(ctx context.Context, settings *kmipapi.ConfigurationSettings, line str
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("locate"), col2, options("id=<value>"), comment("// locate a uid based on a id"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("revoke"), col2, options("uid=<value>"), comment("// revoke a key based on a uid"))
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("destroy"), col2, options("uid=<value>"), comment("// destroy a key based on a uid"))
+
+	fmt.Printf("  %*s  %-*s  %s\n", col1, command("clear"), col2, options("id=<value>"), comment("// locate, revoke, and destroy a key based on id and uid"))
 
 	fmt.Printf("  %*s  %-*s  %s\n", col1, command("register"), col2, options("type=<value> value=<value>"), comment("// Register a new value"))
 }

--- a/src/handlers/key.go
+++ b/src/handlers/key.go
@@ -32,6 +32,9 @@ func CreateKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, lin
 		return
 	}
 
+	// Store the returned uid in ${lastuid} for use in other commands with that variable
+	kmipapi.SetValue(kmipapi.LastUID, uid)
+
 	fmt.Printf("key created for id (%s) returned uid (%s)\n", id, uid)
 }
 
@@ -94,6 +97,9 @@ func LocateKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, lin
 		return
 	}
 
+	// Store the returned uid in ${lastuid} for use in other commands with that variable
+	kmipapi.SetValue(kmipapi.LastUID, uid)
+
 	fmt.Printf("locate key for id (%s) returned uid (%s)\n", id, uid)
 }
 
@@ -135,4 +141,51 @@ func DestroyKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, li
 	}
 
 	fmt.Printf("destroy key succeeded for uid (%s)\n", uid)
+}
+
+// ClearKey: usage 'clear id=<value>' to locate, revoke, and destroy a key based on id and uid
+func ClearKey(ctx context.Context, settings *kmipapi.ConfigurationSettings, line string) {
+	logger := klog.FromContext(ctx)
+	logger.V(2).Info("ClearKey", "line", line)
+
+	id := kmipapi.GetValue(line, "id")
+	if id == "" {
+		fmt.Printf("clear id=value is required, example: clear id=DISK01234\n")
+		return
+	}
+
+	success := true
+
+	uid, err := kmipapi.LocateUid(ctx, settings, id)
+	if err != nil || uid == "" {
+		fmt.Printf("locate failed for id (%s), uid (%d), error: %v\n", id, uid, err)
+		success = false
+	} else {
+		fmt.Printf("locate key for id (%s) returned uid (%s)\n", id, uid)
+		fmt.Printf("\n")
+
+		uid, err = kmipapi.RevokeKey(ctx, settings, uid, uint32(kmip14.RevocationReasonCodeCessationOfOperation))
+		if err != nil {
+			fmt.Printf("revoke key failed for uid (%s) with error: %v\n", uid, err)
+			success = false
+		} else {
+			fmt.Printf("revoke key succeeded for uid (%s)\n", uid)
+		}
+		fmt.Printf("\n")
+
+		uid, err = kmipapi.DestroyKey(ctx, settings, uid)
+		if err != nil {
+			fmt.Printf("destroy key failed for uid (%s) with error: %v\n", uid, err)
+			success = false
+		} else {
+			fmt.Printf("destroy key succeeded for uid (%s)\n", uid)
+		}
+		fmt.Printf("\n")
+	}
+
+	if success {
+		fmt.Printf("clear key succeeded for id (%s)\n", id)
+	} else {
+		fmt.Printf("clear key failed for id (%s)\n", id)
+	}
 }

--- a/src/kmipapi/kmip14.go
+++ b/src/kmipapi/kmip14.go
@@ -72,7 +72,12 @@ func (kmips *kmip14service) Query(ctx context.Context, settings *ConfigurationSe
 		Operation            []kmip14.Operation
 		VendorIdentification string
 	}
-	err = decoder.DecodeValue(&respPayload, item.ResponsePayload.(ttlv.TTLV))
+
+	if item != nil {
+		err = decoder.DecodeValue(&respPayload, item.ResponsePayload.(ttlv.TTLV))
+	} else {
+		err = fmt.Errorf("query response item is nil")
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode QueryResponsePayload, error: %v", err)
@@ -285,7 +290,7 @@ func (kmips *kmip14service) Locate(ctx context.Context, settings *ConfigurationS
 		NameType:  kmip14.NameTypeUninterpretedTextString,
 	}
 	payload := kmip.LocateRequestPayload{}
-	payload.Attribute = append(payload.Attribute, kmip.NewAttributeFromTag(kmip14.TagName, 0, Name))
+	payload.Attributes = append(payload.Attributes, kmip.NewAttributeFromTag(kmip14.TagName, 0, Name))
 
 	decoder, item, err := SendRequestMessage(ctx, settings, uint32(kmip14.OperationLocate), &payload)
 	if err != nil {
@@ -303,13 +308,8 @@ func (kmips *kmip14service) Locate(ctx context.Context, settings *ConfigurationS
 
 	logger.V(4).Info("XXX Locate response payload", "respPayload", respPayload)
 
-	uids := respPayload.UniqueIdentifier
+	uid := respPayload.UniqueIdentifier
 	logger.V(4).Info("XXX Locate response payload", "uid", respPayload.UniqueIdentifier)
-
-	uid := ""
-	if len(uids) > 0 {
-		uid = uids[0]
-	}
 
 	return &LocateResponse{UniqueIdentifier: uid}, nil
 }

--- a/src/kmipapi/parsers.go
+++ b/src/kmipapi/parsers.go
@@ -1,8 +1,15 @@
 package kmipapi
 
 import (
+	"fmt"
 	"strings"
 )
+
+const (
+	LastUID = "lastuid"
+)
+
+var g_variables = map[string]string{}
 
 // GetCommand: returns the first string from a command line, separated by spaces
 func GetCommand(line string) string {
@@ -31,5 +38,23 @@ func GetValue(line, key string) string {
 		}
 	}
 
+	// Check the special case where the user passed in a ${variable}
+	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
+		variable := strings.Replace(value, "${", "", 1)
+		variable = strings.Replace(variable, "}", "", 1)
+
+		newvalue, ok := g_variables[variable]
+		if ok {
+			value = newvalue
+		} else {
+			fmt.Printf("No value stored for (%s)\n", variable)
+		}
+	}
+
 	return value
+}
+
+// SetValue: store a value in a global table to be used with script variables ${variable}
+func SetValue(key, value string) {
+	g_variables[key] = value
 }

--- a/src/kmipapi/types.go
+++ b/src/kmipapi/types.go
@@ -3,6 +3,7 @@ package kmipapi
 import "crypto/tls"
 
 type ConfigurationSettings struct {
+	SaveSettingsToFile   bool      `json:"save_settings_to_file"`  // Save the configuration settings to a file
 	SettingsFile         string    `json:"settings_file"`          // Configuration settings storage file
 	KmsServerName        string    `json:"kms_server_name"`        // KMS server name for informational purposes
 	KmsServerIp          string    `json:"kms_server_ip"`          // KMS server IP address
@@ -14,4 +15,5 @@ type ConfigurationSettings struct {
 	ProtocolVersionMajor int       `json:"protocol_version_major"` // Major version, 1, 2, or 3
 	ProtocolVersionMinor int       `json:"protocol_version_minor"` // Minor version for 1.4 or 2.0
 	ServiceType          string    `json:"service_type"`           // The KMIP version service string, kmip14, kmip20, etc
+	ShowElapsed          bool      `json:"show_elapsed"`           // Display the elapsed time for each command executed.
 }


### PR DESCRIPTION
- Added new command `banner title=value` to print a single word banner.
  - Example:
    - `banner title=PyKMIP`
  - Output:
    - ============================== PyKMIP ==============================
- Added new command `set elapsed=true|false` which displays command elapsed time when true
- Added new command `clear id=value` which will locate, revoke, and destroy a key based on an id
- Added new variable concept, with one new variable `${lastuid}` which is set after a Create or Locate call. 
- Example script using last uid variable:
  - `load file=kms-pykmip.json`
  - `open`
  - `create id=DISKSM0123456789`
  - `activate uid=${lastuid}`
  - `get uid=${lastuid}`
  - `locate id=DISKSM0123456789`
  - `revoke uid=${lastuid}`
  - `destroy uid=${lastuid}`
  - `close`

Signed-off-by: Joe Skazinski <joseph.skazinski@seagate.com>

-----
[View rendered cmd/kms/CHANGELOG.md](https://github.com/Seagate/kmip-go/blob/feat/kms120/cmd/kms/CHANGELOG.md)